### PR TITLE
Add redirection to latest installation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,6 +63,19 @@ const config = {
       copyright: `Copyright © 2020-${new Date().getFullYear()} CloudSkiff.`,
     },
   },
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            to: `/${latestVersion}/installation`,
+            from: '/installation',
+          },
+        ],
+      },
+    ],
+  ],
   presets: [],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/plugin-client-redirects": "^2.0.0-alpha.70",
         "@docusaurus/preset-classic": "2.0.0-alpha.70",
         "@mdx-js/react": "^1.6.21",
         "clsx": "^1.1.1",
@@ -1689,6 +1690,30 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-SAKHEXomBx4bRbP36RQ4PIkJOLAU3y9v4RV8B5sDuEq70g+7Y9yXb4+5P9VC1/L2laMThluqSY+73uRAQs84Sg==",
+      "dependencies": {
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
+        "@docusaurus/utils-validation": "2.0.0-alpha.70",
+        "chalk": "^3.0.0",
+        "eta": "^1.11.0",
+        "fs-extra": "^9.0.1",
+        "globby": "^10.0.1",
+        "joi": "^17.2.1",
+        "lodash": "^4.17.20"
+      },
+      "engines": {
+        "node": ">=10.9.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4",
+        "react-dom": "^16.8.4"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
@@ -19159,6 +19184,23 @@
             "json5": "^2.1.2"
           }
         }
+      }
+    },
+    "@docusaurus/plugin-client-redirects": {
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-SAKHEXomBx4bRbP36RQ4PIkJOLAU3y9v4RV8B5sDuEq70g+7Y9yXb4+5P9VC1/L2laMThluqSY+73uRAQs84Sg==",
+      "requires": {
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
+        "@docusaurus/utils-validation": "2.0.0-alpha.70",
+        "chalk": "^3.0.0",
+        "eta": "^1.11.0",
+        "fs-extra": "^9.0.1",
+        "globby": "^10.0.1",
+        "joi": "^17.2.1",
+        "lodash": "^4.17.20"
       }
     },
     "@docusaurus/plugin-content-blog": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.70",
+    "@docusaurus/plugin-client-redirects": "^2.0.0-alpha.70",
     "@docusaurus/preset-classic": "2.0.0-alpha.70",
     "@mdx-js/react": "^1.6.21",
     "clsx": "^1.1.1",


### PR DESCRIPTION
To fix cloudskiff/driftctl/issues/317, let's redirect /installation to /<latest>/installation