### PR TITLE
More information about how to use the limited role

### DIFF
--- a/docs/providers/aws/authentication.mdx
+++ b/docs/providers/aws/authentication.mdx
@@ -28,6 +28,21 @@ Deploy this CloudFormation template to create our limited permission role that y
 
 [![Launch Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home?#/stacks/quickcreate?stackName=driftctl-stack&templateURL=https://driftctl-cfn-templates.s3.eu-west-3.amazonaws.com/driftctl-role.yml)
 
+Once the stack is deployed, you need to attach the following policy to your IAM User which will allow him to assume only the role. For more information about granting a user access to assume a role, see the official [IAM User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_permissions-to-switch.html).
+
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::<IDOFYOURACCOUNT>:role/driftctl_assume_role"
+    }
+  ]
+}
+```
+
 ### Update the CloudFormation template
 
 It does not exist an automatic way to update the CloudFormation template from our side because you launched this template on your AWS account. That's why you must be the one to update the template to be on the most recent driftctl role.


### PR DESCRIPTION
It misses an explanation about how to attach and use our limited role after launching the CloudFormation stack.