### PR TITLE
Add usage example for http & gitlab

### DIFF
--- a/docs/usage/cmd/scan.mdx
+++ b/docs/usage/cmd/scan.mdx
@@ -93,6 +93,21 @@ driftctl needs read-only access so you could use the policy below to ensure mini
 }
 ```
 
+#### HTTP + Gitlab
+
+The HTTP backend supports fetching the Terraform state from Gitlab using their REST API.
+
+All you need is a Gitlab repository that contains a Terraform state and an access token with the `read_api` scope.
+
+Here's what the command looks like :
+
+```shell
+$ GITLAB_TOKEN=<access_token> \
+driftctl scan \
+--from tfstate+https://gitlab.com/api/v4/projects/<project_id>/terraform/state/<path_to_state> \
+--headers "Authorization=Bearer $GITLAB_TOKEN"
+```
+
 ## --output
 
 driftctl supports multiple kinds of output formats and by default uses the standard output (console).

--- a/docs/usage/cmd/scan.mdx
+++ b/docs/usage/cmd/scan.mdx
@@ -95,7 +95,7 @@ driftctl needs read-only access so you could use the policy below to ensure mini
 
 #### HTTP + Gitlab
 
-The HTTP backend supports fetching the Terraform state from Gitlab using their REST API.
+The HTTP backend supports the GitLab managed Terraform State using their API.
 
 All you need is a Gitlab repository that contains a Terraform state and an access token with the `read_api` scope.
 
@@ -107,6 +107,8 @@ driftctl scan \
 --from tfstate+https://gitlab.com/api/v4/projects/<project_id>/terraform/state/<path_to_state> \
 --headers "Authorization=Bearer $GITLAB_TOKEN"
 ```
+
+You can find more information about the GitLab managed Terraform State on the [GitLab documentation website](https://docs.gitlab.com/ee/user/infrastructure/terraform_state.html).
 
 ## --output
 

--- a/docs/usage/cmd/scan.mdx
+++ b/docs/usage/cmd/scan.mdx
@@ -93,11 +93,11 @@ driftctl needs read-only access so you could use the policy below to ensure mini
 }
 ```
 
-#### HTTP + Gitlab
+#### HTTP + GitLab
 
 The HTTP backend supports the GitLab managed Terraform State using their API.
 
-All you need is a Gitlab repository that contains a Terraform state and an access token with the `read_api` scope.
+All you need is a GitLab repository that contains a Terraform state and an access token with the `read_api` scope.
 
 Here's what the command looks like :
 


### PR DESCRIPTION
Adding an example for Gitlab Terraform state with HTTP backend, following https://github.com/cloudskiff/driftctl/issues/270.

----

![image](https://user-images.githubusercontent.com/16480203/111811066-f6355000-88d6-11eb-9c68-0ac4b8f239b6.png)
