### PR TITLE
.driftignore takes precedence over filter rules

### DIFF
--- a/docs/usage/filtering/driftignore.mdx
+++ b/docs/usage/filtering/driftignore.mdx
@@ -41,3 +41,7 @@ aws_lambda_function.*.Environment
 # Will ignore lastModified for my-lambda-name lambda function
 aws_lambda_function.my-lambda-name.LastModified
 ```
+
+## Precedence over filter rules
+
+The above mechanism to ignore resources can be used in combination with filter rules. Bear in mind that if the same resource is included by a filter rule and excluded inside the .driftignore file, driftctl will just ignore this resource.


### PR DESCRIPTION
Related to #43.

We should talk about .driftignore file taking precedence over filter rules.