### PR TITLE
Support for Terraform Cloud / Terraform Enterprise

### DIFF
--- a/docs/usage/cmd/scan.mdx
+++ b/docs/usage/cmd/scan.mdx
@@ -60,7 +60,7 @@ $ driftctl scan --from tfstate+https://example.com/terraform.tfstate --headers '
 # You can read the current state version for a Workspace from Terraform Cloud/Terraform Enterprise
 # Don't forget to provide your Terraform Cloud API token
 #
-$ driftctl scan --from tfstate+tfcloud://$WORKSPACE_ID --tfc-token $TFCLOUD_TOKEN
+$ driftctl scan --from tfstate+tfcloud://$WORKSPACE_ID --tfc-token $TFC_TOKEN
 ```
 
 ### Supported IaC sources

--- a/docs/usage/cmd/scan.mdx
+++ b/docs/usage/cmd/scan.mdx
@@ -56,6 +56,11 @@ $ driftctl scan --from tfstate://my-states/directory
 #
 # You can use the --headers option if you need to add extra headers to the request (e.g: for authentication purposes)
 $ driftctl scan --from tfstate+https://example.com/terraform.tfstate --headers 'Authorization=Basic ...; X-Custom-Header=value'
+
+# You can read the current state version for a Workspace from Terraform Cloud/Terraform Enterprise
+# Don't forget to provide your Terraform Cloud API token
+#
+$ driftctl scan --from tfstate+tfcloud://$WORKSPACE_ID --tfc-token $TFCLOUD_TOKEN
 ```
 
 ### Supported IaC sources
@@ -64,6 +69,7 @@ $ driftctl scan --from tfstate+https://example.com/terraform.tfstate --headers '
 - Local: `--from tfstate://terraform.tfstate`
 - S3: `--from tfstate+s3://my-bucket/path/to/state.tfstate`
 - HTTPS: `--from tfstate+https://my-url/state.tfstate`
+- Terraform Cloud / Terraform Enterprise: `--from tfstate+tfcloud://WORKSPACE_ID`
 
 You can use any unsupported backend by using `terraform` to pipe your state in a file and then use this file with driftctl:
 
@@ -110,28 +116,6 @@ driftctl scan \
 ```
 
 You can find more information about the GitLab managed Terraform State on the [GitLab documentation website](https://docs.gitlab.com/ee/user/infrastructure/terraform_state.html).
-
-#### HTTP + Terraform Cloud
-
-The HTTP backend supports the Terraform Cloud using their API.
-
-All you need is a Terraform Cloud access token and a workspace identifier.
-
-Here's what the command looks like:
-
-```shell
-# First, use Terraform API to request the hosted-state-download-url
-$ TFC_TOKEN=<terraform_cloud_token> WORKSPACE_ID=<workspace_id> \
-curl \
-  --header "Authorization: Bearer ${TFC_TOKEN}" \
-  --header "Content-Type: application/vnd.api+json" \
-  https://app.terraform.io/api/v2/workspaces/$WORKSPACE_ID/current-state-version
-
-# Use driftctl with the https endpoint
-$ driftctl scan --from tfstate+https://<hosted-state-download-url>
-```
-
-You can find more information about the Terraform Cloud's API on the [Terraform Cloud documentation website](https://www.terraform.io/docs/cloud/api/index.html).
 
 ## --output
 

--- a/docs/usage/cmd/scan.mdx
+++ b/docs/usage/cmd/scan.mdx
@@ -57,7 +57,7 @@ $ driftctl scan --from tfstate://my-states/directory
 # You can use the --headers option if you need to add extra headers to the request (e.g: for authentication purposes)
 $ driftctl scan --from tfstate+https://example.com/terraform.tfstate --headers 'Authorization=Basic ...; X-Custom-Header=value'
 
-# You can read the current state version for a Workspace from Terraform Cloud/Terraform Enterprise
+# You can also read the current state for a given workspace from Terraform Cloud/Enterprise
 # Don't forget to provide your Terraform Cloud API token
 #
 $ driftctl scan --from tfstate+tfcloud://$WORKSPACE_ID --tfc-token $TFC_TOKEN

--- a/versioned_docs/version-0.8.0/usage/cmd/scan.mdx
+++ b/versioned_docs/version-0.8.0/usage/cmd/scan.mdx
@@ -60,7 +60,7 @@ $ driftctl scan --from tfstate+https://example.com/terraform.tfstate --headers '
 # You can read the current state version for a Workspace from Terraform Cloud/Terraform Enterprise
 # Don't forget to provide your Terraform Cloud API token
 #
-$ driftctl scan --from tfstate+tfcloud://$WORKSPACE_ID --tfc-token $TFCLOUD_TOKEN
+$ driftctl scan --from tfstate+tfcloud://$WORKSPACE_ID --tfc-token $TFC_TOKEN
 ```
 
 ### Supported IaC sources

--- a/versioned_docs/version-0.8.0/usage/cmd/scan.mdx
+++ b/versioned_docs/version-0.8.0/usage/cmd/scan.mdx
@@ -56,6 +56,11 @@ $ driftctl scan --from tfstate://my-states/directory
 #
 # You can use the --headers option if you need to add extra headers to the request (e.g: for authentication purposes)
 $ driftctl scan --from tfstate+https://example.com/terraform.tfstate --headers 'Authorization=Basic ...; X-Custom-Header=value'
+
+# You can read the current state version for a Workspace from Terraform Cloud/Terraform Enterprise
+# Don't forget to provide your Terraform Cloud API token
+#
+$ driftctl scan --from tfstate+tfcloud://$WORKSPACE_ID --tfc-token $TFCLOUD_TOKEN
 ```
 
 ### Supported IaC sources
@@ -64,6 +69,7 @@ $ driftctl scan --from tfstate+https://example.com/terraform.tfstate --headers '
 - Local: `--from tfstate://terraform.tfstate`
 - S3: `--from tfstate+s3://my-bucket/path/to/state.tfstate`
 - HTTPS: `--from tfstate+https://my-url/state.tfstate`
+- Terraform Cloud / Terraform Enterprise: `--from tfstate+tfcloud://WORKSPACE_ID`
 
 You can use any unsupported backend by using `terraform` to pipe your state in a file and then use this file with driftctl:
 
@@ -110,28 +116,6 @@ driftctl scan \
 ```
 
 You can find more information about the GitLab managed Terraform State on the [GitLab documentation website](https://docs.gitlab.com/ee/user/infrastructure/terraform_state.html).
-
-#### HTTP + Terraform Cloud
-
-The HTTP backend supports the Terraform Cloud using their API.
-
-All you need is a Terraform Cloud access token and a workspace identifier.
-
-Here's what the command looks like:
-
-```shell
-# First, use Terraform API to request the hosted-state-download-url
-$ TFC_TOKEN=<terraform_cloud_token> WORKSPACE_ID=<workspace_id> \
-curl \
-  --header "Authorization: Bearer ${TFC_TOKEN}" \
-  --header "Content-Type: application/vnd.api+json" \
-  https://app.terraform.io/api/v2/workspaces/$WORKSPACE_ID/current-state-version
-
-# Use driftctl with the https endpoint
-$ driftctl scan --from tfstate+https://<hosted-state-download-url>
-```
-
-You can find more information about the Terraform Cloud's API on the [Terraform Cloud documentation website](https://www.terraform.io/docs/cloud/api/index.html).
 
 ## --output
 

--- a/versioned_docs/version-0.8.0/usage/cmd/scan.mdx
+++ b/versioned_docs/version-0.8.0/usage/cmd/scan.mdx
@@ -57,7 +57,7 @@ $ driftctl scan --from tfstate://my-states/directory
 # You can use the --headers option if you need to add extra headers to the request (e.g: for authentication purposes)
 $ driftctl scan --from tfstate+https://example.com/terraform.tfstate --headers 'Authorization=Basic ...; X-Custom-Header=value'
 
-# You can read the current state version for a Workspace from Terraform Cloud/Terraform Enterprise
+# You can also read the current state for a given workspace from Terraform Cloud/Enterprise
 # Don't forget to provide your Terraform Cloud API token
 #
 $ driftctl scan --from tfstate+tfcloud://$WORKSPACE_ID --tfc-token $TFC_TOKEN


### PR DESCRIPTION
This PR adds documentation for [Support for Terraform Cloud / Terraform Enterprise](https://github.com/cloudskiff/driftctl/pull/458).