### PR TITLE
Add missing deep link for github auth doc

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -88,6 +88,10 @@ const config = {
             to: `/${latestVersion}/providers/aws/authentication`,
             from: '/aws/policy',
           },
+          {
+            to: `/${latestVersion}/providers/github/authentication`,
+            from: '/github/policy',
+          },
         ],
       },
     ],


### PR DESCRIPTION
related to https://github.com/cloudskiff/driftctl/issues/459

Add a missing deep link for GitHub authentication doc.