### PR TITLE
Change Discord Url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,7 +39,7 @@ const config = {
           ],
         },
         {
-          href: "https://discord.gg/NMCBxtD7Nd",
+          href: "https://discord.gg/7zHQ8r2PgP",
           label: "Discord",
           position: "right",
           "aria-label": "Discord server",


### PR DESCRIPTION
This will redirect our users to `Intros` channel instead of `Stargazer`