### PR TITLE
Fix a typo in AWS authentication

### DIFF
--- a/docs/providers/aws/authentication.mdx
+++ b/docs/providers/aws/authentication.mdx
@@ -24,7 +24,7 @@ $ AWS_PROFILE=driftctlrole driftctl scan
 
 ## Custom credentials to read a state on an S3 backend
 
-If you want to use a different set of AWS credentials to read your state on S3, you can override each specific AWS environment variable with the DCTL_S3_ prefix. The purpose here is to have the choice to read a state in a different region than your infrastructure. Please don't forget to use your usual AWS credentials to read the resources of your actual infrastructure.
+If you want to use a different set of AWS credentials to read your state on S3, you can override each specific AWS environment variable with the `DCTL_S3_` prefix. The purpose here is to have the choice to read a state in a different region than your infrastructure. Please don't forget to use your usual AWS credentials to read the resources of your actual infrastructure.
 
 ```
 # Export a dedicated AWS named profile (or any other AWS environment variables) to read your state in your S3 backend

--- a/versioned_docs/version-0.12.0/providers/aws/authentication.mdx
+++ b/versioned_docs/version-0.12.0/providers/aws/authentication.mdx
@@ -24,7 +24,7 @@ $ AWS_PROFILE=driftctlrole driftctl scan
 
 ## Custom credentials to read a state on an S3 backend
 
-If you want to use a different set of AWS credentials to read your state on S3, you can override each specific AWS environment variable with the DCTL_S3_ prefix. The purpose here is to have the choice to read a state in a different region than your infrastructure. Please don't forget to use your usual AWS credentials to read the resources of your actual infrastructure.
+If you want to use a different set of AWS credentials to read your state on S3, you can override each specific AWS environment variable with the `DCTL_S3_` prefix. The purpose here is to have the choice to read a state in a different region than your infrastructure. Please don't forget to use your usual AWS credentials to read the resources of your actual infrastructure.
 
 ```
 # Export a dedicated AWS named profile (or any other AWS environment variables) to read your state in your S3 backend

--- a/versioned_docs/version-0.13.0/providers/aws/authentication.mdx
+++ b/versioned_docs/version-0.13.0/providers/aws/authentication.mdx
@@ -24,7 +24,7 @@ $ AWS_PROFILE=driftctlrole driftctl scan
 
 ## Custom credentials to read a state on an S3 backend
 
-If you want to use a different set of AWS credentials to read your state on S3, you can override each specific AWS environment variable with the DCTL_S3_ prefix. The purpose here is to have the choice to read a state in a different region than your infrastructure. Please don't forget to use your usual AWS credentials to read the resources of your actual infrastructure.
+If you want to use a different set of AWS credentials to read your state on S3, you can override each specific AWS environment variable with the `DCTL_S3_` prefix. The purpose here is to have the choice to read a state in a different region than your infrastructure. Please don't forget to use your usual AWS credentials to read the resources of your actual infrastructure.
 
 ```
 # Export a dedicated AWS named profile (or any other AWS environment variables) to read your state in your S3 backend

--- a/versioned_docs/version-0.14.0/providers/aws/authentication.mdx
+++ b/versioned_docs/version-0.14.0/providers/aws/authentication.mdx
@@ -24,7 +24,7 @@ $ AWS_PROFILE=driftctlrole driftctl scan
 
 ## Custom credentials to read a state on an S3 backend
 
-If you want to use a different set of AWS credentials to read your state on S3, you can override each specific AWS environment variable with the DCTL_S3_ prefix. The purpose here is to have the choice to read a state in a different region than your infrastructure. Please don't forget to use your usual AWS credentials to read the resources of your actual infrastructure.
+If you want to use a different set of AWS credentials to read your state on S3, you can override each specific AWS environment variable with the `DCTL_S3_` prefix. The purpose here is to have the choice to read a state in a different region than your infrastructure. Please don't forget to use your usual AWS credentials to read the resources of your actual infrastructure.
 
 ```
 # Export a dedicated AWS named profile (or any other AWS environment variables) to read your state in your S3 backend


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/16480203/130052582-04eeb525-280e-4c23-a10b-d5154abc1be1.png)

after:

![image](https://user-images.githubusercontent.com/16480203/130052628-ac4de41f-cb88-4dd0-b550-670c1207e8aa.png)
