### PR TITLE
Add aws_apigatewayv2_vpc_link resource

### DIFF
--- a/docs/providers/aws/resources.mdx
+++ b/docs/providers/aws/resources.mdx
@@ -84,3 +84,4 @@ title: Supported Resources
 | aws_rds_cluster_instance | ✅ |
 | aws_appautoscaling_policy | ✅ |
 | aws_appautoscaling_scheduled_action | ❌ |
+| aws_apigatewayv2_vpc_link | ❌ |


### PR DESCRIPTION
No new permissions needed since AWS use the same `"apigateway:GET",` action for the v2